### PR TITLE
更新 block 的鼠标指针样式

### DIFF
--- a/src/pages/GamePage.vue
+++ b/src/pages/GamePage.vue
@@ -166,4 +166,8 @@ onMounted(() => {
   background: grey;
   cursor: not-allowed;
 }
+
+.block:not(.disabled) {
+  cursor: pointer;
+}
 </style>


### PR DESCRIPTION
目前方块上的鼠标指针是一条竖线，pc 上看起来比较费力，可以把鼠标指针变成 pointer 会美观一点。